### PR TITLE
fix ambiguous unicode characters

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -123,7 +123,7 @@ in
     system.nixos-generate-config.configuration = mkDefault ''
       # Edit this configuration file to define what should be installed on
       # your system.  Help is available in the configuration.nix(5) man page
-      # and in the NixOS manual (accessible by running ‘nixos-help’).
+      # and in the NixOS manual (accessible by running `nixos-help).
 
       { config, pkgs, ... }:
 
@@ -214,7 +214,7 @@ in
 
         # This value determines the NixOS release from which the default
         # settings for stateful data, like file locations and database versions
-        # on your system were taken. It’s perfectly fine and recommended to leave
+        # on your system were taken. It's perfectly fine and recommended to leave
         # this value at the release version of the first install of this system.
         # Before changing this value read the documentation for this option
         # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).


### PR DESCRIPTION
Gitea/Forgejo (rightly) complains about ambiguous Unicode characters in the config file:

<img src="https://user-images.githubusercontent.com/476060/236175294-c6d8cb50-074e-444f-a169-cf47a14bc7fd.png" width="657"/>

This PR fixes them in the template already.
